### PR TITLE
🧪 Add unit tests for sanitize function

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -63,7 +63,7 @@ export function sanitize(html) {
   html = html.replace(/[\s\t\r\n]+on\w+[\s\t\r\n]*=[\s\t\r\n]*["'][^"']*["']/gi, '');
   html = html.replace(/[\s\t\r\n]+on\w+[\s\t\r\n]*=[\s\t\r\n]*[^\s>]*/gi, '');
   // Block javascript:/data: in href/src, including whitespace/newline obfuscation
-  html = html.replace(/(href|src)\s*=\s*["'][\s\t\r\n]*(?:javascript|data|vbscript):[^"']*/gi, '$1="#"');
+  html = html.replace(/(href|src)\s*=\s*(["'])[\s\t\r\n]*(?:javascript|data|vbscript):[\s\S]*?\2/gi, '$1="#"');
   return html;
 }
 

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('utils.js sanitize function', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('fallback: removes script tags', async ({ page }) => {
+    const sanitized = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      const originalDOMPurify = window.DOMPurify;
+      delete window.DOMPurify;
+      const result = sanitize('<script>alert("xss")</script><p>Safe</p>');
+      window.DOMPurify = originalDOMPurify;
+      return result;
+    });
+    expect(sanitized).toBe('<p>Safe</p>');
+  });
+
+  test('fallback: removes other dangerous tags', async ({ page }) => {
+    const sanitized = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      delete window.DOMPurify;
+      return sanitize('<style>body{color:red}</style><iframe></iframe><object></object><embed><form></form><div>Safe</div>');
+    });
+    expect(sanitized).toBe('<div>Safe</div>');
+  });
+
+  test('fallback: removes event handlers', async ({ page }) => {
+    const sanitized = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      delete window.DOMPurify;
+      return sanitize('<div onclick="alert(1)" onmouseover="evil()" class="safe">Content</div>');
+    });
+    expect(sanitized).not.toContain('onclick');
+    expect(sanitized).not.toContain('onmouseover');
+    expect(sanitized).toContain('class="safe"');
+    expect(sanitized).toContain('Content');
+  });
+
+  test('fallback: blocks javascript/data/vbscript URLs', async ({ page }) => {
+    const results = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      delete window.DOMPurify;
+      return {
+        simple: sanitize('<a href="javascript:alert(1)">Link</a>'),
+        obfuscated: sanitize('<a href="  \n  javascript:alert(1)">Link</a>'),
+        data: sanitize('<img src="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+">'),
+        vbscript: sanitize('<a href="vbscript:msgbox(1)">Link</a>')
+      };
+    });
+    expect(results.simple).toContain('href="#"');
+    expect(results.obfuscated).toContain('href="#"');
+    expect(results.data).toContain('src="#"');
+    expect(results.vbscript).toContain('href="#"');
+  });
+
+  test('fallback: handles empty or null input', async ({ page }) => {
+    const sanitized = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      delete window.DOMPurify;
+      return {
+        empty: sanitize(''),
+        nullInput: sanitize(null),
+        undefinedInput: sanitize(undefined)
+      };
+    });
+    expect(sanitized.empty).toBe('');
+    expect(sanitized.nullInput).toBe('');
+    expect(sanitized.undefinedInput).toBe('');
+  });
+
+  test('DOMPurify: uses DOMPurify if available', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      window.DOMPurify = {
+        sanitize: (html, config) => {
+          return `PURIFIED:${html}`;
+        }
+      };
+      return sanitize('<p>Input</p>');
+    });
+    expect(result).toBe('PURIFIED:<p>Input</p>');
+  });
+
+  test('DOMPurify: passes correct configuration', async ({ page }) => {
+    const config = await page.evaluate(async () => {
+      const { sanitize } = await import('/js/utils.js');
+      let capturedConfig = null;
+      window.DOMPurify = {
+        sanitize: (html, cfg) => {
+          capturedConfig = cfg;
+          return html;
+        }
+      };
+      sanitize('<p>Test</p>');
+      return capturedConfig;
+    });
+    expect(config).toBeDefined();
+    expect(config.ALLOWED_TAGS).toContain('p');
+    expect(config.ALLOWED_TAGS).toContain('svg');
+    expect(config.ALLOWED_ATTR).toContain('href');
+    expect(config.ALLOWED_ATTR).toContain('viewBox');
+  });
+});


### PR DESCRIPTION
🎯 **What:** Add unit tests for the `sanitize` utility function in `js/utils.js`. The `sanitize` function uses a dual strategy (DOMPurify with a regex-based fallback). These tests ensure both paths are safe and correctly handled. Also fixed a bug in the fallback regex that left trailing quotes and failed on newline-obfuscated URLs.

📊 **Coverage:**
- Fallback path (no DOMPurify):
  - Removal of `<script>`, `<iframe>`, `<style>`, and other dangerous tags.
  - Removal of `on*` event handlers.
  - Blocking of `javascript:`, `data:`, and `vbscript:` protocols in `href`/`src`.
  - Handling of `null`, `undefined`, and empty string inputs.
- DOMPurify path:
  - Verification that `DOMPurify` is called when available.
  - Verification of the passed configuration (ALLOWED_TAGS, ALLOWED_ATTR).

✨ **Result:** Improved reliability of the core HTML sanitization utility. The added tests provide a safety net for future changes and caught a real bug in the fallback regex logic which has now been fixed.

---
*PR created automatically by Jules for task [10647403175581256193](https://jules.google.com/task/10647403175581256193) started by @abhishekdutta18*