### PR TITLE
🧪 Add error path tests for uploadToStorage XHR failures

### DIFF
--- a/tests/images-upload.spec.js
+++ b/tests/images-upload.spec.js
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('uploadToStorage error paths', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('handles network error (xhr.onerror)', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const originalXHR = window.XMLHttpRequest;
+      window.XMLHttpRequest = function() {
+        const mockXhr = {
+          open: () => {},
+          upload: {},
+          send: function() {
+            setTimeout(() => this.onerror(), 10);
+          }
+        };
+        return mockXhr;
+      };
+
+      try {
+        const { uploadToStorage } = await import('./js/images-upload.js');
+        await uploadToStorage(new File([""], "test.png"));
+        return { success: true };
+      } catch (e) {
+        return { success: false, error: e.message };
+      } finally {
+        window.XMLHttpRequest = originalXHR;
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cloudinary: network error');
+  });
+
+  test('handles timeout error (xhr.ontimeout)', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const originalXHR = window.XMLHttpRequest;
+      window.XMLHttpRequest = function() {
+        const mockXhr = {
+          open: () => {},
+          upload: {},
+          send: function() {
+            setTimeout(() => this.ontimeout(), 10);
+          }
+        };
+        return mockXhr;
+      };
+
+      try {
+        const { uploadToStorage } = await import('./js/images-upload.js');
+        await uploadToStorage(new File([""], "test.png"));
+        return { success: true };
+      } catch (e) {
+        return { success: false, error: e.message };
+      } finally {
+        window.XMLHttpRequest = originalXHR;
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cloudinary: upload timeout');
+  });
+
+  test('handles non-200 HTTP status', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const originalXHR = window.XMLHttpRequest;
+      window.XMLHttpRequest = function() {
+        const mockXhr = {
+          open: () => {},
+          upload: {},
+          send: function() {
+            this.status = 400;
+            this.responseText = JSON.stringify({ error: { message: "Bad Request" } });
+            setTimeout(() => this.onload(), 10);
+          }
+        };
+        return mockXhr;
+      };
+
+      try {
+        const { uploadToStorage } = await import('./js/images-upload.js');
+        await uploadToStorage(new File([""], "test.png"));
+        return { success: true };
+      } catch (e) {
+        return { success: false, error: e.message };
+      } finally {
+        window.XMLHttpRequest = originalXHR;
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cloudinary: Bad Request');
+  });
+
+  test('handles non-200 HTTP status with unparseable response', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const originalXHR = window.XMLHttpRequest;
+      window.XMLHttpRequest = function() {
+        const mockXhr = {
+          open: () => {},
+          upload: {},
+          send: function() {
+            this.status = 500;
+            this.responseText = "Internal Server Error";
+            setTimeout(() => this.onload(), 10);
+          }
+        };
+        return mockXhr;
+      };
+
+      try {
+        const { uploadToStorage } = await import('./js/images-upload.js');
+        await uploadToStorage(new File([""], "test.png"));
+        return { success: true };
+      } catch (e) {
+        return { success: false, error: e.message };
+      } finally {
+        window.XMLHttpRequest = originalXHR;
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cloudinary: HTTP 500');
+  });
+
+  test('handles 200 HTTP status with missing secure_url', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const originalXHR = window.XMLHttpRequest;
+      window.XMLHttpRequest = function() {
+        const mockXhr = {
+          open: () => {},
+          upload: {},
+          send: function() {
+            this.status = 200;
+            this.responseText = JSON.stringify({ url: "http://example.com/image.png" });
+            setTimeout(() => this.onload(), 10);
+          }
+        };
+        return mockXhr;
+      };
+
+      try {
+        const { uploadToStorage } = await import('./js/images-upload.js');
+        await uploadToStorage(new File([""], "test.png"));
+        return { success: true };
+      } catch (e) {
+        return { success: false, error: e.message };
+      } finally {
+        window.XMLHttpRequest = originalXHR;
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cloudinary: no URL');
+  });
+
+  test('handles 200 HTTP status with unparseable JSON', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const originalXHR = window.XMLHttpRequest;
+      window.XMLHttpRequest = function() {
+        const mockXhr = {
+          open: () => {},
+          upload: {},
+          send: function() {
+            this.status = 200;
+            this.responseText = "NOT JSON";
+            setTimeout(() => this.onload(), 10);
+          }
+        };
+        return mockXhr;
+      };
+
+      try {
+        const { uploadToStorage } = await import('./js/images-upload.js');
+        await uploadToStorage(new File([""], "test.png"));
+        return { success: true };
+      } catch (e) {
+        return { success: false, error: e.message };
+      } finally {
+        window.XMLHttpRequest = originalXHR;
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cloudinary: invalid response');
+  });
+});


### PR DESCRIPTION
🎯 **What:**
Added error path testing for `uploadToStorage` in `js/images-upload.js`. 
Because the file relies heavily on DOM globals (`window`, `XMLHttpRequest`, `FormData`, etc.) without providing easy inversion of control, the tests use Playwright's `page.evaluate()` to execute directly in the browser environment, properly mocking `window.XMLHttpRequest` for various failure paths.

📊 **Coverage:**
The following scenarios are now covered:
- Network failures (`xhr.onerror`)
- Upload timeouts (`xhr.ontimeout`)
- Non-200 HTTP responses (e.g. 400 Bad Request)
- Non-200 HTTP responses with unparseable bodies
- 200 HTTP responses missing the expected `secure_url`
- 200 HTTP responses with invalid/unparseable JSON

✨ **Result:**
Test coverage significantly improved. Edge cases that could silently fail or produce unexpected errors in `images-upload.js` are now explicitly tested against expected behavior.

---
*PR created automatically by Jules for task [16091368660564425093](https://jules.google.com/task/16091368660564425093) started by @abhishekdutta18*